### PR TITLE
Fix logging-interceptor artifactId in bom/pom.xml

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -53,7 +53,7 @@
       </dependency>
       <dependency>
         <groupId>${project.groupId}</groupId>
-        <artifactId>okhttp-logging-interceptor</artifactId>
+        <artifactId>logging-interceptor</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
Although it'd probably be a better fix to change the actual artifactId of logging-interceptor to okhttp-logging-interceptor, this is a less disruptive change.